### PR TITLE
FEAT: Implement metrics API for NA graph backend

### DIFF
--- a/cognee/infrastructure/databases/graph/neptune_analytics_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neptune_analytics_driver/adapter.py
@@ -688,6 +688,12 @@ class NeptuneAnalyticsGraphDB(GraphDBInterface):
 
         if include_optional:
             optional_metrics['num_selfloops'] = await self._count_self_loops()
+            # Unsupported due to long-running queries when computing the shortest path for each node in the graph:
+            # optional_metrics['diameter']
+            # optional_metrics['avg_shortest_path_length']
+            #
+            # Unsupported due to incompatible algorithm: localClusteringCoefficient
+            # optional_metrics['avg_clustering']
 
         return mandatory_metrics | optional_metrics
 

--- a/cognee/infrastructure/databases/graph/neptune_analytics_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neptune_analytics_driver/adapter.py
@@ -1060,8 +1060,8 @@ class NeptuneAnalyticsGraphDB(GraphDBInterface):
 
             The count of self-loop relationships found in the database, or 0 if none were found.
         """
-        query = """
-        MATCH (n)-[r]->(n)
+        query = f"""
+        MATCH (n :{self._GRAPH_NODE_LABEL})-[r]->(n :{self._GRAPH_NODE_LABEL})
         RETURN count(r) AS adapter_loop_count;
         """
         result = await self.query(query)

--- a/cognee/infrastructure/databases/graph/neptune_analytics_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neptune_analytics_driver/adapter.py
@@ -999,13 +999,11 @@ class NeptuneAnalyticsGraphDB(GraphDBInterface):
 
             A tuple of nodes and edges data.
         """
-        query_string = """
-            CALL neptune.graph.pg_info()
-            YIELD metric, count
-            WHERE metric in ['numVertices', 'numEdges']
-            RETURN
-              max(CASE WHEN metric = 'numVertices' THEN count END) AS numVertices,
-              max(CASE WHEN metric = 'numEdges' THEN count END) AS numEdges
+        query_string = f"""
+            MATCH (n :{self._GRAPH_NODE_LABEL})
+            WITH count(n) AS nodeCount
+            MATCH (a :{self._GRAPH_NODE_LABEL})-[r]->(b :{self._GRAPH_NODE_LABEL})
+            RETURN nodeCount AS numVertices, count(r) AS numEdges
         """
         query_response = await self.query(query_string)
         num_nodes = query_response[0].get('numVertices')

--- a/cognee/tests/test_neptune_analytics_graph.py
+++ b/cognee/tests/test_neptune_analytics_graph.py
@@ -191,6 +191,12 @@ async def main():
     for subgraph_edge in subgraph_edges:
         print(subgraph_edge)
 
+    print("------STAT-------")
+    stat = await na_adapter.get_graph_metrics()
+    assert type(stat) is dict
+    print(f"Graph statistic: {stat}")
+
+
     print("------DELETE-------")
     # delete all nodes and edges:
     await na_adapter.delete_graph()
@@ -205,5 +211,7 @@ async def main():
     else:
         print(f"Delete failed")
 
+
 if __name__ == "__main__":
     asyncio.run(main())
+

--- a/cognee/tests/test_neptune_analytics_graph.py
+++ b/cognee/tests/test_neptune_analytics_graph.py
@@ -109,6 +109,9 @@ async def main():
     This example demonstrates how to add nodes to Neptune Analytics
     """
 
+    print("------TRUNCATE GRAPH-------")
+    await na_adapter.delete_graph()
+
     print("------SETUP DATA-------")
     nodes, edges = setup()
 
@@ -192,10 +195,19 @@ async def main():
         print(subgraph_edge)
 
     print("------STAT-------")
-    stat = await na_adapter.get_graph_metrics()
+    stat = await na_adapter.get_graph_metrics(include_optional=True)
     assert type(stat) is dict
-    print(f"Graph statistic: {stat}")
-
+    assert stat['num_nodes'] == 7
+    assert stat['num_edges'] == 7
+    assert stat['mean_degree'] == 2.0
+    assert round(stat['edge_density'], 3) == 0.167
+    assert stat['num_connected_components'] == [7]
+    assert stat['sizes_of_connected_components'] == 1
+    assert stat['num_selfloops'] == 0
+    # Unsupported optional metrics
+    assert stat['diameter'] == -1
+    assert stat['avg_shortest_path_length'] == -1
+    assert stat['avg_clustering'] == -1
 
     print("------DELETE-------")
     # delete all nodes and edges:
@@ -211,7 +223,5 @@ async def main():
     else:
         print(f"Delete failed")
 
-
 if __name__ == "__main__":
     asyncio.run(main())
-


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
This PR aims to provide support for the get_metrics functionality of Graph backend, which all mandatory metrics and one optional metric `num_selfloops` will be supported, and the rest will be marked unsupported and value `-1` will be returned indicate that.

Below are the reasons why given metrics are unsupported for Neptune Analytics:
 
 - **diameter / avg_shortest_path_length:** 
This requires either `.sssp.bellmanFor` or `.sssp.deltaStepping` to be executed upon EVERY node in the graph, which is computation expensive and require a dedicated `weight` value under the properties section of the node.

 - **avg_clustering:** 
No equivalent algo on Neptune Analytics to compute the sam.e 




## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
