### PR TITLE
FIX: Serialize lists for properties

### DIFF
--- a/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
@@ -143,7 +143,7 @@ class NeptuneGraphDB(GraphDBInterface):
                 serialized_properties[property_key] = str(property_value)
                 continue
 
-            if isinstance(property_value, dict):
+            if isinstance(property_value, dict) or isinstance(property_value, list):
                 serialized_properties[property_key] = json.dumps(property_value, cls=JSONEncoder)
                 continue
 

--- a/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
@@ -126,7 +126,7 @@ class NeptuneGraphDB(GraphDBInterface):
             raise NeptuneAnalyticsConfigurationError(f"Failed to initialize Neptune Analytics client: {format_neptune_error(e)}")
 
     @staticmethod
-    def serialize_properties(properties: Dict[str, Any]) -> Dict[str, Any]:
+    def _serialize_properties(properties: Dict[str, Any]) -> Dict[str, Any]:
         """
         Serialize properties for Neptune Analytics storage.
         Parameters:
@@ -490,7 +490,7 @@ class NeptuneGraphDB(GraphDBInterface):
 
             # Prepare edge properties
             edge_props = properties or {}
-            serialized_properties = self.serialize_properties(edge_props)
+            serialized_properties = self._serialize_properties(edge_props)
 
             query = f"""
             MATCH (source:{self._GRAPH_NODE_LABEL})
@@ -560,7 +560,7 @@ class NeptuneGraphDB(GraphDBInterface):
                             "from_node": str(edge[0]),
                             "to_node": str(edge[1]),
                             "relationship_name": relationship_name,
-                            "properties": self.serialize_properties(edge[3] if len(edge) > 3 and edge[3] else {}),
+                            "properties": self._serialize_properties(edge[3] if len(edge) > 3 and edge[3] else {}),
                         }
                         for edge in edges_by_relationship
                     ]

--- a/cognee/infrastructure/databases/hybrid/neptune_analytics/NeptuneAnalyticsAdapter.py
+++ b/cognee/infrastructure/databases/hybrid/neptune_analytics/NeptuneAnalyticsAdapter.py
@@ -169,7 +169,7 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
             data_vector = data_vectors[index]
 
             # Fetch properties
-            properties = self.serialize_properties(data_point.model_dump())
+            properties = self._serialize_properties(data_point.model_dump())
             properties[self._COLLECTION_PREFIX] = collection_name
             params = dict(
                 node_id = str(node_id),


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
If a list is included in the properties, NA would return the error saying that only simple literals can be added to properties. With this fix, we JSON-serialize the lists as literals.  

Example `properties`: 
```
'properties': {'id': '467107ed-39ca-4a37-881c-5aa95ad2f563', 'created_at': 1698408373, 'updated_at': 1698408373, 'ontology_valid': False, 'version': 1, 'topological_rank': 0, 'metadata': '{"index_fields": ["name"]}', 'type': 'ProgrammingLanguage', 'belongs_to_set': None, 'name': 'Neptune Analytics', 'used_in': '[]'}
```

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
